### PR TITLE
Terminal string construction isolated from metric calculations. 

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -1,19 +1,18 @@
 const axios = require("axios");
-const rateOfReturn = require("./metrics/return")
-const dailyDrawdown = require("./metrics/drawdown")
-const printEOD = require("./metrics/EODprint")
-require('colors');
+const rateOfReturn = require("./metrics/return");
+const dailyDrawdown = require("./metrics/drawdown");
+const printEOD = require("./metrics/EODprint");
+const terminalMessage = require("./terminal_msg");
 
+require("colors");
 
 // Function requests price data using variables provided by user
 module.exports = function Lillium(stock, dayInit, dayEnd, key) {
-// const apiUrl = `https://www.quandl.com/api/v3/datasets/WIKI/${stock}.json?start_date=${dayInit}&end_date=${dayEnd}&order=asc&api_key=${key}`
-const apiUrl = `https://www.quandl.com/api/v3/datasets/EOD/${stock}.json?start_date=${dayInit}&end_date=${dayEnd}&order=asc&api_key=${key}`
+  // const apiUrl = `https://www.quandl.com/api/v3/datasets/WIKI/${stock}.json?start_date=${dayInit}&end_date=${dayEnd}&order=asc&api_key=${key}`
+  const apiUrl = `https://www.quandl.com/api/v3/datasets/EOD/${stock}.json?start_date=${dayInit}&end_date=${dayEnd}&order=asc&api_key=${key}`;
 
   axios
-    .get(
-      apiUrl
-    )
+    .get(apiUrl)
     .then(function(response) {
       const data = response.data.dataset.data;
       if (data.length === 0)
@@ -21,16 +20,22 @@ const apiUrl = `https://www.quandl.com/api/v3/datasets/EOD/${stock}.json?start_d
           `Source has no price data for this time range try before 2018-03-27`
         );
       if (data.length > 0) {
+        const results = {
+          ror: rateOfReturn(data),
+          dds: dailyDrawdown(data),
+          raw: data
+        };
         console.time("Execution time");
         console.log(`-------------Begin Data for ${stock}------------`.grey);
-        console.log(rateOfReturn(data).bold)
-        console.log(dailyDrawdown(data))
-        console.log(printEOD(data))
+        console.log(terminalMessage(results));
+        // console.log(rateOfReturn(data).bold)
+        // console.log(dailyDrawdown(data))
+        // console.log(printEOD(data))
         console.log(`-------------End of Data for ${stock}------------`.grey);
         console.timeEnd(`Execution time`);
       }
     })
     .catch(function(error) {
-      console.log(error.message,error.response.data.quandl_error);
+      console.log(error.message, error.response.data.quandl_error);
     });
 };

--- a/app/lillium_hardCoded.js
+++ b/app/lillium_hardCoded.js
@@ -4,11 +4,11 @@ const config = require("./config");
 
 // USER INPUT - ADJUST EQUATION INPUTS
 // Stock Ticker
-const ticker = [`hd`]
+const ticker = [`aapl`]
 // Initial Date YYYY-MM-DD  **Blank will result in earliest available date
-const startDate = `2018-03-01`
+const startDate = `2018-01-01`
 // End Date YYYY-MM_DD  ** Blank will result in up price info up to today
-const endDate = `2018-03-25`
+const endDate = `2018-01-05`
 // API KEY **Create a config.js file that exports the key or simply enter below
 const apiKey = config.QuandlKey
 

--- a/app/metrics/EODprint.js
+++ b/app/metrics/EODprint.js
@@ -7,13 +7,11 @@ function printEOD(arr) {
   if (arr.length === 0) {
     return "Price Performance: Data Sent Empty";
   } else {
-    let outputMessage = `Daily Price Performance: 
-  `;
+    let outputMessage = `Daily Price Performance: `+"\n";
     // Collapse Price array if it is not in our interests to print
     if (arr.length > 50) {
       arr = [arr[0], arr[arr.length - 1]];
-      outputMessage = `Daily Price Performance: Data Collapsed for printing purposes...
-  `;
+      outputMessage = `Daily Price Performance: Data Collapsed for printing purposes...`+"\n";
     }
     arr.forEach(el => {
       // Set variables used in message
@@ -21,8 +19,8 @@ function printEOD(arr) {
       let close = el[4];
       let high = el[2];
       let low = el[3];
-      outputMessage += `${date}: Closed at ${close} (${low} ~ ${high})
-    `;
+      outputMessage += `${date}: Closed at ${close} (${low} ~ ${high})`;
+      outputMessage += "\n";
     });
     return outputMessage;
   }

--- a/app/metrics/drawdown.js
+++ b/app/metrics/drawdown.js
@@ -11,7 +11,7 @@ function dailyDrawdown(arr) {
     let trough = arr[0][3];
     let troughDate;
     let drawDownArr = [];
-    let maximumDrawDown = { drawdown: 0 };
+    let maximumDrawDown = { drawDown: 0 };
     arr.forEach(el => {
       // Quandl Data Api returns an array of [Date, Open, High, Low, Close]
       let dayHigh = el[2];
@@ -34,7 +34,7 @@ function dailyDrawdown(arr) {
       let drawDown = Math.min(0, (((dayLow - peak) / peak) * 100).toFixed(1));
       if (newPeak || drawDownArr.length === 0) {
         drawDownArr.push({
-          drawdown: Number(drawDown),
+          drawDown: Number(drawDown),
           peak: peak,
           pDate: peakDate,
           trough: dayLow,
@@ -43,7 +43,7 @@ function dailyDrawdown(arr) {
       } else if (!newPeak && newTrough) {
         drawDownArr.pop();
         drawDownArr.push({
-          drawdown: Number(drawDown),
+          drawDown: Number(drawDown),
           peak: peak,
           pDate: peakDate,
           trough: dayLow,
@@ -52,9 +52,9 @@ function dailyDrawdown(arr) {
       }
 
       // Save the maximum drawdown
-      if (drawDown < maximumDrawDown.drawdown)
+      if (drawDown < maximumDrawDown.drawDown)
         maximumDrawDown = {
-          drawdown: Number(drawDown),
+          drawDown: Number(drawDown),
           peak: peak,
           pDate: peakDate,
           trough: dayLow,
@@ -62,26 +62,12 @@ function dailyDrawdown(arr) {
         };
     });
 
-    // BUILD CONSOLE DISPLAY STRINGS
-    maximumDrawDownOutput = `Maximum Drawdown: ${maximumDrawDown.drawdown}% (${
-      maximumDrawDown.peak
-    } on ${maximumDrawDown.pDate} -> ${maximumDrawDown.trough} on ${
-      maximumDrawDown.tDate
-    })
-`;
-    firstThreeDDOutput = `First 3 Drawdowns: 
-  ${drawDownArr[0].drawdown}% (${drawDownArr[0].peak} on ${
-      drawDownArr[0].pDate
-    } -> ${drawDownArr[0].trough} on ${drawDownArr[0].tDate})
-  ${drawDownArr[1].drawdown}% (${drawDownArr[1].peak} on ${
-      drawDownArr[1].pDate
-    } -> ${drawDownArr[1].trough} on ${drawDownArr[1].tDate})
-  ${drawDownArr[2].drawdown}% (${drawDownArr[2].peak} on ${
-      drawDownArr[2].pDate
-    } -> ${drawDownArr[2].trough} on ${drawDownArr[2].tDate})
-  `;
-    outputMessage = maximumDrawDownOutput + firstThreeDDOutput;
-    return outputMessage;
+    const ddOutput = {
+      maximumDrawDown: maximumDrawDown,
+      drawDownArr: drawDownArr,
+    }
+
+    return ddOutput
   }
 }
 

--- a/app/metrics/return.js
+++ b/app/metrics/return.js
@@ -16,12 +16,18 @@ function rateOfReturn(arr) {
     let ror = endPrice - startPrice;
     let rorPercent = (ror / startPrice) * 100;
 
-    // Build Output String
-    outputMessage = `Return: $${ror.toFixed(2)} [${rorPercent.toFixed(
-      1
-    )}%] ( ${startPrice} on ${startDate} -> ${endPrice} on ${endDate} )
-    `;
-    return outputMessage;
+    rorOutput = {
+      return: ror,
+      returnP: rorPercent,
+      startDate: startDate,
+      startPrice: startPrice,
+      endDate: endDate,
+      endPrice: endPrice
+    }
+
+    return rorOutput
+
+   
   }
 }
 

--- a/app/terminal_msg.js
+++ b/app/terminal_msg.js
@@ -1,0 +1,39 @@
+// Prepares a console message string to print to terminal
+const printEOD = require("./metrics/EODprint");
+
+function terminalMessage(arr) {
+  // Build Return String
+  let returnMessage = `Return: $${arr.ror.return.toFixed(
+    2
+  )} [${arr.ror.returnP.toFixed(1)}%] ( ${arr.ror.startPrice} on ${
+    arr.ror.startDate
+  } -> ${arr.ror.endPrice} on ${arr.ror.endDate} )
+    `;
+
+  // Build Max Drawdown String
+  let maximumDrawDownMessage = `Maximum Drawdown: ${
+    arr.dds.maximumDrawDown.drawDown
+  }% (${arr.dds.maximumDrawDown.peak} on ${arr.dds.maximumDrawDown.pDate} -> ${
+    arr.dds.maximumDrawDown.trough
+  } on ${arr.dds.maximumDrawDown.tDate})
+  `;
+
+// Build drawdown String
+  let firstDDMessage =`First 3 Drawdowns: `+"\n"
+  let limit = Math.min(3,arr.dds.drawDownArr.length)
+  for(let i = 0; i<limit; i++){
+    firstDDMessage += `${arr.dds.drawDownArr[i].drawDown}% (${arr.dds.drawDownArr[i].peak} on ${
+        arr.dds.drawDownArr[i].pDate
+           } -> ${arr.dds.drawDownArr[i].trough} on ${arr.dds.drawDownArr[i].tDate})`+"\n"
+  }
+
+// Build price history String
+  const historyMessage = printEOD(arr.raw)
+//   const historyMessage = "\n" 
+
+
+// Assemble and return
+  const outputMessage = returnMessage+"\n" +maximumDrawDownMessage+"\n"+firstDDMessage+"\n"+historyMessage;
+  return outputMessage;
+}
+module.exports = terminalMessage;


### PR DESCRIPTION
Through TTD: I realized that my metrics were both calculating and printing strings.
I removed all string construction to another file and had each calculator return their results to an object in the index.js.
Results yielded fast execution time however, tests will need to be re-written for the new function setup.

terminal_msg now contains the constructed strings. & SideEffect: most test n/a